### PR TITLE
ci: fix for code scanning alert: workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-go-check.yml
+++ b/.github/workflows/pr-go-check.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/alex-vosk/strip-ansi/security/code-scanning/2](https://github.com/alex-vosk/strip-ansi/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs build/test commands, it only needs read access to repository contents. The best way to do this is to add the following at the top level of the workflow (after the `name:` field and before `on:`), which will apply to all jobs in the workflow:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed. Only a single edit to the YAML file is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
