### PR TITLE
ci: fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-go-check.yml
+++ b/.github/workflows/pr-go-check.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go PR Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/alex-vosk/strip-ansi/security/code-scanning/3](https://github.com/alex-vosk/strip-ansi/security/code-scanning/3)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the least privilege required. For a workflow that only checks out code and runs build/test commands, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to that job). The best practice is to add the following at the top level of the workflow file, just after the `name` field and before the `on` field. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
